### PR TITLE
Fix product brief template literal termination

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -64,7 +64,7 @@ Constraints & risks: {{constraints}}
 Deliverables:
 - Scope and guardrails
 - Launch timeline (high-level)
-- Success definition`}
+- Success definition`
   },
   {
     id: 'bug_report',


### PR DESCRIPTION
## Summary
- remove the stray closing brace from the product brief base template literal so the object syntax remains valid

## Testing
- node --check assets/js/main.js
- playwright smoke script to load http://127.0.0.1:3000 and ensure the builder initializes without console errors

------
https://chatgpt.com/codex/tasks/task_e_68d1319dbf588323ac99843426e0dcd0